### PR TITLE
Remove package method in service provider

### DIFF
--- a/src/Latrell/Geohash/GeohashServiceProvider.php
+++ b/src/Latrell/Geohash/GeohashServiceProvider.php
@@ -20,7 +20,7 @@ class GeohashServiceProvider extends ServiceProvider
 	 */
 	public function boot()
 	{
-		$this->package('latrell/geohash');
+		//
 	}
 
 	/**


### PR DESCRIPTION
Package method is not supported in Laravel 5 and is not required in Laravel 4
